### PR TITLE
Fix various escaping issues

### DIFF
--- a/lib/lucene-query-parser.js
+++ b/lib/lucene-query-parser.js
@@ -181,17 +181,17 @@ module.exports = (function() {
         peg$c70 = "\\/",
         peg$c71 = { type: "literal", value: "\\/", description: "\"\\\\/\"" },
         peg$c72 = function(term) {
-              return term.replace(/\\\//g, '/');
+              return term; //unescapeTerm(term); //.replace(/\\\//g, '/');
             },
         peg$c73 = /^[^\/]/,
         peg$c74 = { type: "class", value: "[^/]", description: "[^/]" },
         peg$c75 = "\"",
         peg$c76 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c77 = /^[^"]/,
-        peg$c78 = { type: "class", value: "[^\"]", description: "[^\"]" },
-        peg$c79 = function(term) {
-                return term;
+        peg$c77 = function(term) {
+                return term.replace(/\\"/g, '"');
             },
+        peg$c78 = /^[^"]/,
+        peg$c79 = { type: "class", value: "[^\"]", description: "[^\"]" },
         peg$c80 = "~",
         peg$c81 = { type: "literal", value: "~", description: "\"~\"" },
         peg$c82 = function(proximity) {
@@ -1343,26 +1343,10 @@ module.exports = (function() {
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         s3 = [];
-        if (peg$c77.test(input.charAt(peg$currPos))) {
-          s4 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
-        }
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            if (peg$c77.test(input.charAt(peg$currPos))) {
-              s4 = input.charAt(peg$currPos);
-              peg$currPos++;
-            } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c78); }
-            }
-          }
-        } else {
-          s3 = peg$FAILED;
+        s4 = peg$parsequoted_char();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parsequoted_char();
         }
         if (s3 !== peg$FAILED) {
           s2 = input.substring(s2, peg$currPos);
@@ -1379,7 +1363,7 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c79(s2);
+            s1 = peg$c77(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1392,6 +1376,29 @@ module.exports = (function() {
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsequoted_char() {
+      var s0;
+
+      if (input.substr(peg$currPos, 2) === peg$c58) {
+        s0 = peg$c58;
+        peg$currPos += 2;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      }
+      if (s0 === peg$FAILED) {
+        if (peg$c78.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+        }
       }
 
       return s0;
@@ -2352,10 +2359,18 @@ module.exports = (function() {
          return result;
        }
 
-       var escapedTerms = /\\(\s|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
+       // Chars that should be escaped in unquoted terms
+       var escapedUnquotedTermChars = /\\(\s|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
+
+       // Chars that should be escaped in RegExs
+       var escapedRegExChars = /\\(\s|\.|\$|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
 
        function unescapeTerm(term) {
-         return term.replace(escapedTerms, '$1')
+         return term.replace(escapedUnquotedTermChars, '$1')
+       }
+
+       function unescapeRegExTerm(term) {
+         return term.replace(escapedRegExChars, '$1')
        }
      
 

--- a/lib/lucene-query.grammar
+++ b/lib/lucene-query.grammar
@@ -86,10 +86,18 @@
      return result;
    }
 
-   var escapedTerms = /\\(\s|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
+   // Chars that should be escaped in unquoted terms
+   var escapedUnquotedTermChars = /\\(\s|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
+
+   // Chars that should be escaped in RegExs
+   var escapedRegExChars = /\\(\s|\.|\$|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
 
    function unescapeTerm(term) {
-     return term.replace(escapedTerms, '$1')
+     return term.replace(escapedUnquotedTermChars, '$1')
+   }
+
+   function unescapeRegExTerm(term) {
+     return term.replace(escapedRegExChars, '$1')
    }
  }
 
@@ -231,19 +239,21 @@ escaped_term_char
 regexpr_term
   = '/' term:$regexpr_char+ '/'
     {
-      return term.replace(/\\\//g, '/');
+      return term; //unescapeTerm(term); //.replace(/\\\//g, '/');
     }
 
 regexpr_char
   = '.' / '\\/' / [^/]
 
 
-
 quoted_term
-  = '"' term:$[^"]+ '"'
+  = '"' term:$quoted_char* '"'
     {
-        return term;
+        return term.replace(/\\"/g, '"');
     }
+
+quoted_char
+  = '\\"' / [^"]
 
 proximity_modifier
   = '~' proximity:int_exp

--- a/lib/lucene-query.grammar
+++ b/lib/lucene-query.grammar
@@ -89,15 +89,8 @@
    // Chars that should be escaped in unquoted terms
    var escapedUnquotedTermChars = /\\(\s|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
 
-   // Chars that should be escaped in RegExs
-   var escapedRegExChars = /\\(\s|\.|\$|\+|\-|&|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|\:|\\|\/)/g;
-
    function unescapeTerm(term) {
      return term.replace(escapedUnquotedTermChars, '$1')
-   }
-
-   function unescapeRegExTerm(term) {
-     return term.replace(escapedRegExChars, '$1')
    }
  }
 
@@ -239,7 +232,7 @@ escaped_term_char
 regexpr_term
   = '/' term:$regexpr_char+ '/'
     {
-      return term; //unescapeTerm(term); //.replace(/\\\//g, '/');
+      return term;
     }
 
 regexpr_char

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucene-query-parser",
-  "version": "1.0.2-autopilot.1",
+  "version": "1.0.2-autopilot.2",
   "description": "Lucene Query Parser for Javascript created using PEG.js",
   "main": "lib/lucene-query-parser.js",
   "scripts": {

--- a/spec/lucene-query-parser.spec.js
+++ b/spec/lucene-query-parser.spec.js
@@ -66,11 +66,21 @@ describe("lucenequeryparser: term parsing", function() {
 
     it("parses quoted terms", function() {
       var results = lucenequeryparser.parse('"fizz buzz"');
-
       expect(results.term).toBe('fizz buzz');
       expect(results.unquoted).toBeUndefined();
     });
 
+    it("parses quoted terms that contain double quotes", function() {
+      var results = lucenequeryparser.parse('"fizz \\"buzz\\""');
+      expect(results.term).toBe('fizz "buzz"');
+      expect(results.unquoted).toBeUndefined();
+    });
+
+    it("parses empty quoted terms", function() {
+      var results = lucenequeryparser.parse('""');
+      expect(results.term).toBe('');
+      expect(results.unquoted).toBeUndefined();
+    });
 
     it("parses terms with +", function() {
         var results = lucenequeryparser.parse('fizz+buzz');
@@ -91,17 +101,26 @@ describe("lucenequeryparser: term parsing", function() {
         expect(results.regexpr).toBe(true);
     });
 
+    it("parses term with regular expression", function() {
+        var allTheThings = '[0-9a-zA-Z\\u00a1-\\uffff\\:\\-\\/\\_\\@\\.\\?#\\%\\+\\=\\&\\$\\*]*';
+        var results = lucenequeryparser.parse('industry_match:/' + allTheThings + 'foo' + allTheThings + '/');
+
+        expect(results.term).toBe(allTheThings + 'foo' + allTheThings);
+        expect(results.regexpr).toBe(true);
+    });
+
+
     it("parses term with regular expression containing /", function() {
         var results = lucenequeryparser.parse('/fizz\\/buzz/');
 
-        expect(results.term).toBe('fizz/buzz');
+        expect(results.term).toBe('fizz\\/buzz');
         expect(results.regexpr).toBe(true);
     });
 
     it("parses term with regular expression that begins with //", function() {
         var results = lucenequeryparser.parse('url_match:/\\/\\/example.com\\/products\\/example.html/');
 
-        expect(results.term).toBe('//example.com/products/example.html');
+        expect(results.term).toBe('\\/\\/example.com\\/products\\/example.html');
         expect(results.regexpr).toBe(true);
     });
 


### PR DESCRIPTION
- ensure that escaped double quotes inside quoted expressions can be parsed
- handle escaped chars in regular expressions
- handle empty quoted expressions

Please ignore `lib/lucene-query-parser.js`, it's the generated version of `lib/lucene-query.grammar`
